### PR TITLE
Adds setTimeout to loading of plugin.

### DIFF
--- a/www/device.js
+++ b/www/device.js
@@ -44,6 +44,15 @@ function Device() {
 
     var me = this;
 
+    // On certain platforms, like iOS, the failure callback won't be
+    // executed if the device native code does not exist. In this case we
+    // set a timeout to fire the channel. We choose 4.9 seconds as Cordova
+    // complains at 5 seconds.
+    var timeout = setTimeout(function() {
+      me.available = false;
+      channel.onCordovaInfoReady.fire();
+    }, 4900);
+
     channel.onCordovaReady.subscribe(function() {
         me.getInfo(function(info) {
             //ignoring info.cordova returning from native, we should use value from cordova.version defined in cordova.js
@@ -56,12 +65,14 @@ function Device() {
             me.cordova = buildLabel;
             me.model = info.model;
             channel.onCordovaInfoReady.fire();
+            clearTimeout(timeout);
         },function(e) {
             me.available = false;
             if (console && console.error) {
               console.error("[ERROR] Error initializing Cordova Device Plugin: " + e);
             }
             channel.onCordovaInfoReady.fire();
+            clearTimeout(timeout);
         });
     });
 }


### PR DESCRIPTION
In the case where the native code does not exist on the device
the failure callback may not execute. This is true for some
platforms, i.e. iOS. In this case we set a timeout to make the
device module unavailable if no callback is fired after five
seconds.